### PR TITLE
feat: sync overlay elements

### DIFF
--- a/server/index.esm.js
+++ b/server/index.esm.js
@@ -47,6 +47,10 @@ app.post('/api/overlay', (req,res)=>{ Object.assign(state.overlay, req.body||{})
 io.on('connection', (socket)=>{
   socket.emit('init', { overlay: state.overlay, devices: state.devices, intiface: state.intiface });
   socket.on('overlay:set', (ov)=>{ Object.assign(state.overlay, ov||{}); io.emit('overlay:update', state.overlay); });
+  socket.on('elements:get', ()=> socket.emit('overlay:elements', state.overlay.elements));
+  socket.on('element:add', (el)=>{ if(!el) return; const i = state.overlay.elements.findIndex(e=>e.id===el.id); if(i>=0) state.overlay.elements[i]=el; else state.overlay.elements.push(el); io.emit('overlay:elements', state.overlay.elements); });
+  socket.on('element:update', (el)=>{ if(!el||el.id==null) return; const i = state.overlay.elements.findIndex(e=>e.id===el.id); if(i>=0) Object.assign(state.overlay.elements[i], el); else state.overlay.elements.push(el); io.emit('overlay:elements', state.overlay.elements); });
+  socket.on('element:delete', (id)=>{ const elId = typeof id==='object'? id.id:id; const i = state.overlay.elements.findIndex(e=>e.id===elId); if(i>=0){ state.overlay.elements.splice(i,1); io.emit('overlay:elements', state.overlay.elements); } });
 });
 
 // Default → control


### PR DESCRIPTION
## Summary
- add WebSocket handlers for overlay element CRUD operations
- keep overlay elements synced across clients via `overlay:elements`

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b486c0886c83339a558320eb93483e