### PR TITLE
Add overlay element socket handlers

### DIFF
--- a/server/index.esm.js
+++ b/server/index.esm.js
@@ -1,4 +1,4 @@
-// server/index.esm.js — v53 (ESM)
+// server/index.esm.js — v54 (ESM)
 import express from 'express';
 import http from 'http';
 import { Server as SocketIO } from 'socket.io';
@@ -47,6 +47,16 @@ app.post('/api/overlay', (req,res)=>{ Object.assign(state.overlay, req.body||{})
 io.on('connection', (socket)=>{
   socket.emit('init', { overlay: state.overlay, devices: state.devices, intiface: state.intiface });
   socket.on('overlay:set', (ov)=>{ Object.assign(state.overlay, ov||{}); io.emit('overlay:update', state.overlay); });
+  socket.on('element:add', el => { state.overlay.elements.push(el); io.emit('overlay:elements', state.overlay.elements); });
+  socket.on('element:update', el => {
+    const i = state.overlay.elements.findIndex(e => e.id === el.id);
+    if(i !== -1){ state.overlay.elements[i] = el; io.emit('overlay:elements', state.overlay.elements); }
+  });
+  socket.on('elements:get', () => socket.emit('overlay:elements', state.overlay.elements));
+  socket.on('element:delete', id => {
+    const i = state.overlay.elements.findIndex(e => e.id === id);
+    if(i !== -1){ state.overlay.elements.splice(i,1); io.emit('overlay:elements', state.overlay.elements); }
+  });
 });
 
 // Default → control

--- a/server/index.js
+++ b/server/index.js
@@ -1,4 +1,4 @@
-// server/index.js — v53 (CJS)
+// server/index.js — v54 (CJS)
 const express = require('express');
 const http = require('http');
 const { Server: SocketIO } = require('socket.io');
@@ -23,7 +23,20 @@ app.get('/api/devices', (req,res)=> res.json({ ok:true, devices: state.devices, 
 app.post('/api/emit-tip', async (req,res)=>{ const amt = Number((req.body&&req.body.amount)||50); state.overlay.goalProgress = Math.min(state.overlay.goalTarget, state.overlay.goalProgress + amt); io.emit('overlay:goal',{ target: state.overlay.goalTarget, current: state.overlay.goalProgress }); await vibrateAll(state, Math.min(1, Math.max(.25, amt/250)), 1200); res.json({ ok:true }); });
 app.post('/api/overlay', (req,res)=>{ Object.assign(state.overlay, req.body||{}); io.emit('overlay:update', state.overlay); res.json({ok:true}); });
 
-io.on('connection', (socket)=>{ socket.emit('init', { overlay: state.overlay, devices: state.devices, intiface: state.intiface }); socket.on('overlay:set', (ov)=>{ Object.assign(state.overlay, ov||{}); io.emit('overlay:update', state.overlay); }); });
+io.on('connection', (socket)=>{
+  socket.emit('init', { overlay: state.overlay, devices: state.devices, intiface: state.intiface });
+  socket.on('overlay:set', (ov)=>{ Object.assign(state.overlay, ov||{}); io.emit('overlay:update', state.overlay); });
+  socket.on('element:add', el => { state.overlay.elements.push(el); io.emit('overlay:elements', state.overlay.elements); });
+  socket.on('element:update', el => {
+    const i = state.overlay.elements.findIndex(e => e.id === el.id);
+    if(i !== -1){ state.overlay.elements[i] = el; io.emit('overlay:elements', state.overlay.elements); }
+  });
+  socket.on('elements:get', ()=> socket.emit('overlay:elements', state.overlay.elements));
+  socket.on('element:delete', id => {
+    const i = state.overlay.elements.findIndex(e => e.id === id);
+    if(i !== -1){ state.overlay.elements.splice(i,1); io.emit('overlay:elements', state.overlay.elements); }
+  });
+});
 
 app.get('*', (req,res)=> res.sendFile(path.join(__dirname,'../public/control.html')));
 


### PR DESCRIPTION
## Summary
- broadcast overlay element additions, updates, deletions, and retrievals
- mirror socket handlers in ESM build

## Testing
- `npm test` *(fails: Missing script "test")*
- `node server/index.js` & socket.io client scripts to add/update/delete elements and request element list

------
https://chatgpt.com/codex/tasks/task_e_68b55555dd008333ac08cab7c5110008