### PR TITLE
Fix selection overlay scaling to match canvas

### DIFF
--- a/web/control.html
+++ b/web/control.html
@@ -30,11 +30,12 @@
         <div id="stage" class="stage">
           <div class="grid"></div>
           <div class="glow" id="stageGlow"></div>
-          <div class="canvas-abs" id="canvas"></div>
-          <div id="sel" class="sel">
-            <div class="h nw"></div><div class="h n"></div><div class="h ne"></div>
-            <div class="h w"></div><div class="h e"></div>
-            <div class="h sw"></div><div class="h s"></div><div class="h se"></div>
+          <div class="canvas-abs" id="canvas">
+            <div id="sel" class="sel">
+              <div class="h nw"></div><div class="h n"></div><div class="h ne"></div>
+              <div class="h w"></div><div class="h e"></div>
+              <div class="h sw"></div><div class="h s"></div><div class="h se"></div>
+            </div>
           </div>
           <img class="watermark" src="/img/watermark.svg" id="wm">
         </div>
@@ -134,6 +135,7 @@ function render(){
     canvas.appendChild(node);
     const li=document.createElement('li'); li.textContent=`${el.type} — ${el.id}`; li.onclick=()=>select(el.id); document.getElementById('layers').appendChild(li);
   });
+  canvas.appendChild(sel);
   wm.style.display = settings.showWatermark?'block':'none'; glow.style.display = settings.glow?'block':'none';
   if(selected){ showSel(); } else sel.style.display='none';
   wire();

--- a/web/css/style.css
+++ b/web/css/style.css
@@ -22,7 +22,7 @@
 .pill{background:var(--pill); border-radius:18px; box-shadow:0 10px 30px rgba(120,60,140,.18);}
 .goal{background:#eef1f6b0; border-radius:18px; backdrop-filter: blur(6px); box-shadow: inset 0 0 0 1px rgba(100,120,150,.18);}
 .label{position:absolute;top:-28px;left:0;font-weight:800;letter-spacing:.02em}
-.sel{ outline:2px dashed #8fb6ff; border-radius:12px; position:absolute; display:none }
+.sel{ outline:2px dashed #8fb6ff; border-radius:12px; position:absolute; display:none; transform-origin:0 0 }
 .h{ position:absolute; width:10px; height:10px; background:#fff; border:1px solid #6ea1ff; border-radius:50%; box-shadow:0 1px 2px rgba(0,0,0,.2) }
 .h.n{ top:-6px; left:50%; transform:translate(-50%,-50%) } .h.s{ bottom:-6px; left:50%; transform:translate(-50%,50%) }
 .h.e{ right:-6px; top:50%; transform:translate(50%,-50%) } .h.w{ left:-6px; top:50%; transform:translate(-50%,-50%) }


### PR DESCRIPTION
## Summary
- move selection rectangle into the canvas container and reattach during render
- ensure selection overlay shares transform origin with canvas

## Testing
- `npm test` (fails: Missing script "test")
- `npm start`

------
https://chatgpt.com/codex/tasks/task_e_68b5596de0708333a9cab340acc30dd8