### PR TITLE
feat: add Intiface connect handler and rename device events

### DIFF
--- a/public/js/control.js
+++ b/public/js/control.js
@@ -45,7 +45,7 @@ makeDraggable(document.getElementById('title'));
 makeDraggable(document.getElementById('goalbar'));
 
 // Devices list
-ioSock.on('devices:update', list=>{
+ioSock.on('intiface:devices', list=>{
   const box = document.getElementById('devList'); if(!box) return; box.innerHTML='';
   (list||[]).forEach(d=>{
     const row = document.createElement('div'); row.className='dev-row';

--- a/server/cjs/intiface.cjs
+++ b/server/cjs/intiface.cjs
@@ -31,7 +31,7 @@ async function scanOnce(client, state, io){
 function emitDevices(client, state, io){
   const list = client?.Devices || client?.devices || [];
   state.devices = list.map(d=>({ index: d.Index ?? d.index, name: d.Name ?? d.name, canVibrate: !!(d.AllowedMessages?.VibrateCmd) }));
-  io.emit('devices:update', state.devices);
+  io.emit('intiface:devices', state.devices);
 }
 
 async function vibrateAll(state, strength=.65, durationMs=1200){

--- a/server/index.esm.js
+++ b/server/index.esm.js
@@ -57,6 +57,11 @@ io.on('connection', (socket)=>{
     const i = state.overlay.elements.findIndex(e => e.id === id);
     if(i !== -1){ state.overlay.elements.splice(i,1); io.emit('overlay:elements', state.overlay.elements); }
   });
+  socket.on('intiface:connect', async url => {
+    await connectIntiface(url ?? state.intiface.url, state, io);
+    socket.emit('intiface:devices', state.devices);
+    io.emit('intiface:status', state.intiface);
+  });
 });
 
 // Default → control

--- a/server/index.js
+++ b/server/index.js
@@ -37,6 +37,11 @@ io.on('connection', (socket)=>{
     const i = state.overlay.elements.findIndex(e => e.id === id);
     if(i !== -1){ state.overlay.elements.splice(i,1); io.emit('overlay:elements', state.overlay.elements); }
   });
+  socket.on('intiface:connect', async url => {
+    await connectIntiface(url ?? state.intiface.url, state, io);
+    socket.emit('intiface:devices', state.devices);
+    io.emit('intiface:status', state.intiface);
+  });
 });
 
 app.get('*', (req,res)=> res.sendFile(path.join(__dirname,'../public/control.html')));

--- a/server/intiface.esm.js
+++ b/server/intiface.esm.js
@@ -38,7 +38,7 @@ export function emitDevices(client, state, io){
     name: d.Name ?? d.name,
     canVibrate: !!(d.AllowedMessages?.VibrateCmd),
   }));
-  io.emit('devices:update', state.devices);
+  io.emit('intiface:devices', state.devices);
 }
 
 export async function vibrateAll(state, strength=.65, durationMs=1200){

--- a/server/intiface.js
+++ b/server/intiface.js
@@ -31,7 +31,7 @@ async function scanOnce(client, state, io){
 function emitDevices(client, state, io){
   const list = client?.Devices || client?.devices || [];
   state.devices = list.map(d=>({ index: d.Index ?? d.index, name: d.Name ?? d.name, canVibrate: !!(d.AllowedMessages?.VibrateCmd) }));
-  io.emit('devices:update', state.devices);
+  io.emit('intiface:devices', state.devices);
 }
 
 async function vibrateAll(state, strength=.65, durationMs=1200){

--- a/web/control.html
+++ b/web/control.html
@@ -194,7 +194,10 @@ document.getElementById('save').onclick=()=>{ socket.emit('settings:update',{ sh
 document.getElementById('emit').onclick=()=> socket.emit('tip', { amount:100, user:'Tester' });
 document.getElementById('goalR').onclick=()=> socket.emit('overlay:goal-reached', {});
 document.getElementById('quit').onclick=()=> fetch('/app/quit').catch(()=>{});
-document.getElementById('btnConn').onclick=()=> socket.emit('intiface:connect', document.getElementById('ws').value);
+document.getElementById('btnConn').onclick=()=>{
+  const url=document.getElementById('ws').value;
+  fetch('/api/intiface/connect',{method:'POST', body:JSON.stringify({url})});
+};
 // sockets
 socket.on('overlay:settings', s=>{ settings={...settings,...s}; document.getElementById('wmChk').checked=!!settings.showWatermark; document.getElementById('glowChk').checked=!!settings.glow; document.getElementById('goal').value=settings.goalTarget||2000; render(); });
 socket.on('overlay:elements', list=>{ elements=list||[]; render(); });

--- a/web/js/control.js
+++ b/web/js/control.js
@@ -45,7 +45,7 @@ makeDraggable(document.getElementById('title'));
 makeDraggable(document.getElementById('goalbar'));
 
 // Devices list
-ioSock.on('devices:update', list=>{
+ioSock.on('intiface:devices', list=>{
   const box = document.getElementById('devList'); if(!box) return; box.innerHTML='';
   (list||[]).forEach(d=>{
     const row = document.createElement('div'); row.className='dev-row';


### PR DESCRIPTION
## Summary
- add `intiface:connect` socket handler that connects to Intiface and shares device/status updates
- rename `devices:update` event to `intiface:devices` across server and client
- use HTTP POST to connect Intiface from control page

## Testing
- `npm install`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_68b559666e3c8333a9d8a8815860fe5d