### PR TITLE
feat: add socket tip handler and reuse logic

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -15,12 +15,18 @@ app.use(express.static(path.join(__dirname,'../web')));
 
 const state = { overlay:{ goalTarget:2000, goalProgress:0, glow:true, watermark:true, elements:[] }, devices:[], intiface:{ url:'ws://127.0.0.1:12345', connected:false }, bpClient:null };
 
+async function handleTip(amount = 100){
+  state.overlay.goalProgress = Math.min(state.overlay.goalTarget, state.overlay.goalProgress + amount);
+  io.emit('overlay:goal', { target: state.overlay.goalTarget, current: state.overlay.goalProgress });
+  await vibrateAll(state, Math.min(1, Math.max(.25, amount / 250)), 1200);
+}
+
 app.post('/api/intiface/connect', async (req,res)=>{
   try{ const url = (req.body&&req.body.url) || state.intiface.url; state.intiface.url = url; await connectIntiface(url, state, io); res.json({ ok:true, devices: state.devices }); }
   catch(e){ res.status(500).json({ ok:false, error: String(e) }); }
 });
 app.get('/api/devices', (req,res)=> res.json({ ok:true, devices: state.devices, connected: state.intiface.connected }));
-app.post('/api/emit-tip', async (req,res)=>{ const amt = Number((req.body&&req.body.amount)||50); state.overlay.goalProgress = Math.min(state.overlay.goalTarget, state.overlay.goalProgress + amt); io.emit('overlay:goal',{ target: state.overlay.goalTarget, current: state.overlay.goalProgress }); await vibrateAll(state, Math.min(1, Math.max(.25, amt/250)), 1200); res.json({ ok:true }); });
+app.post('/api/emit-tip', async (req,res)=>{ const amt = Number((req.body&&req.body.amount)||50); await handleTip(amt); res.json({ ok:true }); });
 app.post('/api/overlay', (req,res)=>{ Object.assign(state.overlay, req.body||{}); io.emit('overlay:update', state.overlay); res.json({ok:true}); });
 
 io.on('connection', (socket)=>{
@@ -36,6 +42,9 @@ io.on('connection', (socket)=>{
   socket.on('element:delete', id => {
     const i = state.overlay.elements.findIndex(e => e.id === id);
     if(i !== -1){ state.overlay.elements.splice(i,1); io.emit('overlay:elements', state.overlay.elements); }
+  });
+  socket.on('tip', async ({amount = 100}) => {
+    await handleTip(amount);
   });
 });
 


### PR DESCRIPTION
## Summary
- handle tip events over Socket.IO
- reuse centralized tipping logic for HTTP endpoint

## Testing
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b55972442c833386973e766a3659c5