### PR TITLE
Ensure Electron window launches in fullscreen

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -10,7 +10,7 @@ function startServer(){
   server.on('exit', ()=> server=null);
 }
 function createWindow(){
-  win = new BrowserWindow({ width: 1280, height: 820, backgroundColor: '#00000000', autoHideMenuBar: true });
+  win = new BrowserWindow({ backgroundColor: '#00000000', autoHideMenuBar: true, fullscreen: true, minWidth: 1280, minHeight: 820 });
   win.loadURL('http://localhost:3000/splash.html').catch(()=>{});
   setTimeout(()=> win.loadURL('http://localhost:3000/control.html'), 1500);
   win.on('closed', ()=>{ if(server) server.kill(); });


### PR DESCRIPTION
## Summary
- Launch Electron BrowserWindow in fullscreen with 1280x820 minimum size

## Testing
- `npm test` *(fails: Missing script: "test" )*
- `timeout 5 xvfb-run -a npx electron . --no-sandbox` *(errors: Failed to load splash due to connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68b55974e440833380eeab787d9916cd