### PR TITLE
Rename HTTP import to avoid conflicts

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -3,11 +3,10 @@ const { app, BrowserWindow, screen } = require('electron');
 const path = require('path');
 const { fork } = require('child_process');
 
-const http = require('http');
+const nodeHttp = require('http');
 const fs = require('fs');
 
 const { spawn } = require('child_process');
-const http = require('http');
 
 let server = null, win = null;
 
@@ -44,13 +43,13 @@ function waitForServer(url, cb){
   const start = Date.now();
   (function check(){
 
-    http.get(url, ()=> cb(true)).on('error', ()=>{
+    nodeHttp.get(url, ()=> cb(true)).on('error', ()=>{
       if(Date.now() - start > 10000) return cb(false);
 
-    http.get(url, ()=> cb(true)).on('error', ()=>{
+    nodeHttp.get(url, ()=> cb(true)).on('error', ()=>{
       if(Date.now() - start > 10000) return cb(false);
 
-    http.get(url, ()=> cb()).on('error', ()=>{
+    nodeHttp.get(url, ()=> cb()).on('error', ()=>{
       if(Date.now() - start > 10000) return cb();
       setTimeout(check, 200);
     });


### PR DESCRIPTION
## Summary
- rename `http` import to `nodeHttp`
- update network calls to use `nodeHttp.get`

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run app` *(fails: error while loading shared libraries: libatk-1.0.so.0)*

------
https://chatgpt.com/codex/tasks/task_e_68b563b56da08333a9d6d348fb592afa