### PR TITLE
Remove duplicate HTTP require and fix server startup in Electron entrypoint

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/app/main.js
+++ b/app/main.js
@@ -1,14 +1,8 @@
-
 const { app, BrowserWindow, screen } = require('electron');
 const path = require('path');
 const { fork } = require('child_process');
 const nodeHttp = require('http');
 const fs = require('fs');
-
-const nodeHttp = require('http');
-const fs = require('fs');
-
-const { spawn } = require('child_process');
 
 let server = null, win = null;
 
@@ -25,7 +19,6 @@ function startServer(){
     stdio:'ignore',
     windowsHide:true,
     env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }
-
   });
   server.on('exit', ()=> server=null);
   server.on('error', err=>{ console.error('[ButtCaster] failed to start server', err); server=null; });
@@ -40,44 +33,6 @@ function waitForServer(url, cb){
     });
   })();
 }
-
-
-    windowsHide:true
-
-
-  server = fork(path.join(__dirname,'../server/index.js'), {
-    cwd: path.join(__dirname,'..'),
-    stdio:'ignore',
-    windowsHide:true
-
-  server = spawn(process.execPath, [path.join(__dirname,'../server/index.js')], {
-    stdio:'ignore',
-    windowsHide:true,
-    env:{ ...process.env, ELECTRON_RUN_AS_NODE:'1' }
-  });
-  server.on('exit', ()=> server=null);
-  server.on('error', err=>{ console.error('[ButtCaster] failed to start server', err); server=null; });
-}
-
-function waitForServer(url, cb){
-  const start = Date.now();
-  (function check(){
-    nodeHttp.get(url, ()=> cb(true)).on('error', ()=>{
-      if(Date.now() - start > 10000) return cb(false);
-
-    nodeHttp.get(url, ()=> cb(true)).on('error', ()=>{
-      if(Date.now() - start > 10000) return cb(false);
-
-    nodeHttp.get(url, ()=> cb(true)).on('error', ()=>{
-      if(Date.now() - start > 10000) return cb(false);
-
-    nodeHttp.get(url, ()=> cb()).on('error', ()=>{
-      if(Date.now() - start > 10000) return cb();
-      setTimeout(check, 200);
-    });
-  })();
-}
-
 
 function createWindow(){
   const { width, height, x, y } = screen.getPrimaryDisplay().workArea;
@@ -87,15 +42,9 @@ function createWindow(){
     if(ok) win.loadURL('http://localhost:3000/control.html');
     else win.webContents.executeJavaScript("document.querySelector('.tip').textContent='Server failed to start';");
   });
-
-
-  waitForServer('http://localhost:3000/', ()=> win.loadURL('http://localhost:3000/control.html'));
-  win = new BrowserWindow({ backgroundColor: '#00000000', autoHideMenuBar: true, fullscreen: true, minWidth: 1280, minHeight: 820 });
-  win.loadURL('http://localhost:3000/splash.html').catch(()=>{});
-  setTimeout(()=> win.loadURL('http://localhost:3000/control.html'), 1500);
-
   win.on('closed', ()=>{ if(server) server.kill(); });
 }
 
 app.whenReady().then(()=>{ startServer(); createWindow(); });
 app.on('window-all-closed', ()=> app.quit());
+

--- a/server/index.js
+++ b/server/index.js
@@ -47,6 +47,7 @@ io.on('connection', (socket)=>{
     await connectIntiface(url ?? state.intiface.url, state, io);
     socket.emit('intiface:devices', state.devices);
     io.emit('intiface:status', state.intiface);
+  });
   socket.on('tip', async ({amount = 100}) => {
     await handleTip(amount);
   });


### PR DESCRIPTION
## Summary
- clean up `app/main.js` by defining `nodeHttp` only once
- drop duplicate, obsolete server-startup code
- ignore `node_modules` with a .gitignore entry
- fix server script crash by closing the `intiface:connect` handler

## Testing
- `node --check server/index.js`
- `node --check app/main.js`
- `npm test` *(fails: Missing script: "test")*
- `npm run app` *(fails: error while loading shared libraries: libdrm.so.2)*

------
https://chatgpt.com/codex/tasks/task_e_68b5799ccd2c8333a44a690d3d60fdb1