### PR TITLE
Remove duplicate HTTP require and fix socket.io client routing

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+node_modules/
+

--- a/app/main.js
+++ b/app/main.js
@@ -1,14 +1,8 @@
-
 const { app, BrowserWindow, screen } = require('electron');
 const path = require('path');
 const { fork } = require('child_process');
 const nodeHttp = require('http');
 const fs = require('fs');
-
-const nodeHttp = require('http');
-const fs = require('fs');
-
-const { spawn } = require('child_process');
 
 let server = null, win = null;
 
@@ -22,12 +16,14 @@ function startServer(){
   }
   server = fork(serverPath, {
     cwd: path.dirname(serverPath),
-    stdio:'ignore',
+    stdio:'inherit',
     windowsHide:true,
     env: { ...process.env, ELECTRON_RUN_AS_NODE: '1' }
-
   });
-  server.on('exit', ()=> server=null);
+  server.on('exit', code=>{
+    if(code) console.error(`[ButtCaster] server exited with code ${code}`);
+    server=null;
+  });
   server.on('error', err=>{ console.error('[ButtCaster] failed to start server', err); server=null; });
 }
 
@@ -40,44 +36,6 @@ function waitForServer(url, cb){
     });
   })();
 }
-
-
-    windowsHide:true
-
-
-  server = fork(path.join(__dirname,'../server/index.js'), {
-    cwd: path.join(__dirname,'..'),
-    stdio:'ignore',
-    windowsHide:true
-
-  server = spawn(process.execPath, [path.join(__dirname,'../server/index.js')], {
-    stdio:'ignore',
-    windowsHide:true,
-    env:{ ...process.env, ELECTRON_RUN_AS_NODE:'1' }
-  });
-  server.on('exit', ()=> server=null);
-  server.on('error', err=>{ console.error('[ButtCaster] failed to start server', err); server=null; });
-}
-
-function waitForServer(url, cb){
-  const start = Date.now();
-  (function check(){
-    nodeHttp.get(url, ()=> cb(true)).on('error', ()=>{
-      if(Date.now() - start > 10000) return cb(false);
-
-    nodeHttp.get(url, ()=> cb(true)).on('error', ()=>{
-      if(Date.now() - start > 10000) return cb(false);
-
-    nodeHttp.get(url, ()=> cb(true)).on('error', ()=>{
-      if(Date.now() - start > 10000) return cb(false);
-
-    nodeHttp.get(url, ()=> cb()).on('error', ()=>{
-      if(Date.now() - start > 10000) return cb();
-      setTimeout(check, 200);
-    });
-  })();
-}
-
 
 function createWindow(){
   const { width, height, x, y } = screen.getPrimaryDisplay().workArea;
@@ -85,17 +43,13 @@ function createWindow(){
   win.loadFile(path.join(__dirname,'../web/splash.html'));
   waitForServer('http://localhost:3000/', (ok)=>{
     if(ok) win.loadURL('http://localhost:3000/control.html');
-    else win.webContents.executeJavaScript("document.querySelector('.tip').textContent='Server failed to start';");
+    else win.webContents
+      .executeJavaScript("document.querySelector('.tip').textContent='Server failed to start';")
+      .catch(err => console.error('[ButtCaster] failed to update splash screen', err));
   });
-
-
-  waitForServer('http://localhost:3000/', ()=> win.loadURL('http://localhost:3000/control.html'));
-  win = new BrowserWindow({ backgroundColor: '#00000000', autoHideMenuBar: true, fullscreen: true, minWidth: 1280, minHeight: 820 });
-  win.loadURL('http://localhost:3000/splash.html').catch(()=>{});
-  setTimeout(()=> win.loadURL('http://localhost:3000/control.html'), 1500);
-
   win.on('closed', ()=>{ if(server) server.kill(); });
 }
 
 app.whenReady().then(()=>{ startServer(); createWindow(); });
 app.on('window-all-closed', ()=> app.quit());
+

--- a/server/index.js
+++ b/server/index.js
@@ -6,8 +6,9 @@ const path = require('path');
 const { connectIntiface, vibrateAll } = require('./intiface.js');
 
 const app = express();
-const server = http.createServer(app);
+const server = http.createServer();
 const io = new SocketIO(server, { cors: { origin: '*' } });
+server.on('request', app);
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname,'../public')));
@@ -47,11 +48,12 @@ io.on('connection', (socket)=>{
     await connectIntiface(url ?? state.intiface.url, state, io);
     socket.emit('intiface:devices', state.devices);
     io.emit('intiface:status', state.intiface);
+  });
   socket.on('tip', async ({amount = 100}) => {
     await handleTip(amount);
   });
 });
 
-app.get('*', (req,res)=> res.sendFile(path.join(__dirname,'../public/control.html')));
+app.get('/', (req,res)=> res.sendFile(path.join(__dirname,'../web/control.html')));
 
 const PORT = process.env.PORT || 3000; server.listen(PORT, ()=> console.log(`[ButtCaster] server on http://localhost:${PORT}`));


### PR DESCRIPTION
## Summary
- clean up `app/main.js` by defining `nodeHttp` only once
- drop duplicate, obsolete server-startup code
- ignore `node_modules` with a .gitignore entry
- fix server script crash by closing the `intiface:connect` handler
- serve Socket.IO client correctly by attaching Express after `socket.io` and routing `/`
- surface backend launch errors by inheriting server stdio and logging non-zero exit codes
- catch splash-screen script failures to avoid unhandled promise rejections

## Testing
- `node --check server/index.js`
- `node --check app/main.js`
- `npm test` *(fails: Missing script: "test")*
- `npm run app` *(fails: electron: not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b5799ccd2c8333a44a690d3d60fdb1