### PR TITLE
Scale control preview with window size

### DIFF
--- a/web/control.html
+++ b/web/control.html
@@ -118,7 +118,8 @@ const wm=document.getElementById('wm'), glow=document.getElementById('stageGlow'
 let settings={showWatermark:true, glow:true, goalTarget:2000, goalValue:0}; let elements=[]; let selected=null;
 
 // preview scale 960x540 ↔ 1920x1080
-function scale(){ const s=960/1920; document.querySelector('.canvas-abs').style.transform=`scale(${s})`; }
+let scaleFactor=960/1920;
+function scale(){ const s=Math.min(window.innerWidth/1920, window.innerHeight/1080); scaleFactor=s; document.querySelector('.canvas-abs').style.transform=`scale(${s})`; }
 scale(); addEventListener('resize', scale);
 
 // Render
@@ -150,7 +151,7 @@ function attachResize(h, el, k){
   h.onpointerdown=(e)=>{ h.setPointerCapture(e.pointerId);
     const start={x:e.clientX,y:e.clientY, ex:el.x, ey:el.y, ew:el.w||600, eh:el.h||60};
     function mv(ev){
-      const dx=(ev.clientX-start.x)/0.5, dy=(ev.clientY-start.y)/0.5;
+      const dx=(ev.clientX-start.x)/scaleFactor, dy=(ev.clientY-start.y)/scaleFactor;
       let x=el.x, y=el.y, w=el.w||600, h=el.h||60;
       if(k.includes('e')) w=Math.max(20, Math.round(start.ew+dx));
       if(k.includes('s')) h=Math.max(20, Math.round(start.eh+dy));
@@ -167,8 +168,8 @@ function wire(){
     node.onclick=()=>select(node.dataset.id);
     const el=elements.find(e=>e.id===node.dataset.id);
     node.onpointerdown=(e)=>{ if(e.button!==0) return; node.setPointerCapture(e.pointerId);
-      const s=0.5; const start={x:e.clientX,y:e.clientY, ex:el.x, ey:el.y};
-      node.onpointermove=(ev)=>{ const dx=(ev.clientX-start.x)/s, dy=(ev.clientY-start.y)/s; el.x=Math.round(start.ex+dx); el.y=Math.round(start.ey+dy); socket.emit('element:update',el); showSel(); };
+      const start={x:e.clientX,y:e.clientY, ex:el.x, ey:el.y};
+      node.onpointermove=(ev)=>{ const dx=(ev.clientX-start.x)/scaleFactor, dy=(ev.clientY-start.y)/scaleFactor; el.x=Math.round(start.ex+dx); el.y=Math.round(start.ey+dy); socket.emit('element:update',el); showSel(); };
       node.onpointerup=()=>{ node.onpointermove=null; };
     };
   });


### PR DESCRIPTION
## Summary
- scale preview dynamically based on window size
- recompute scale on resize and apply to interactions

## Testing
- `npm test` *(fails: Missing script: "test")*


------
https://chatgpt.com/codex/tasks/task_e_68b58826b0cc8333a3c9a4602425f1cd