### PR TITLE
refactor: remove duplicate server definitions

### DIFF
--- a/server/index.js
+++ b/server/index.js
@@ -18,10 +18,6 @@ const app = express();
 // Use a uniquely named variable to avoid accidental re‑declarations.
 const httpServer = http.createServer(app);
 const io = new SocketIO(httpServer, { cors: { origin: '*' } });
-const server = http.createServer(app);
-const server = http.createServer();
-const io = new SocketIO(server, { cors: { origin: '*' } });
-server.on('request', app);
 
 app.use(express.json());
 app.use(express.static(path.join(__dirname,'../public')));
@@ -71,9 +67,3 @@ app.get('/', (req,res)=> res.sendFile(path.join(__dirname,'../web/control.html')
 
 const PORT = process.env.PORT || 3000;
 httpServer.listen(PORT, ()=> console.log(`[ButtCaster] server on http://localhost:${PORT}`));
-const PORT = process.env.PORT || 3000;
-httpServer.listen(PORT, ()=> console.log(`[ButtCaster] server on http://localhost:${PORT}`));
-server.on('request', app);
-
-const PORT = process.env.PORT || 3000;
-server.listen(PORT, ()=> console.log(`[ButtCaster] server on http://localhost:${PORT}`));


### PR DESCRIPTION
## Summary
- remove duplicate http server and Socket.IO declarations in server/index.js
- avoid redundant listen calls so the server only binds once

## Testing
- `node server/index.js`

------
https://chatgpt.com/codex/tasks/task_e_68b59530dd888333bdfa3846fd3ed846