### PR TITLE
Handle Intiface connect errors in control page

### DIFF
--- a/web/control.html
+++ b/web/control.html
@@ -209,12 +209,11 @@ document.getElementById('goalR').onclick=()=> socket.emit('overlay:goal-reached'
 document.getElementById('quit').onclick=()=> fetch('/app/quit').catch(()=>{});
 document.getElementById('btnConn').onclick=()=>{
   const url=document.getElementById('ws').value;
-  fetch('/api/intiface/connect',{method:'POST', body:JSON.stringify({url})});
   fetch('/api/intiface/connect', {
     method: 'POST',
     headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify({ url })
-  });
+  }).catch(err => console.error('Intiface connect failed', err));
 };
 // sockets
 socket.on('overlay:settings', s=>{ settings={...settings,...s}; document.getElementById('wmChk').checked=!!settings.showWatermark; document.getElementById('glowChk').checked=!!settings.glow; document.getElementById('goal').value=settings.goalTarget||2000; render(); });


### PR DESCRIPTION
## Summary
- Simplify Intiface connection handler to a single POST request
- Log connection failures to aid debugging

## Testing
- `npm test` *(fails: Missing script: "test")*

------
https://chatgpt.com/codex/tasks/task_e_68b595c18e5c83339bf51adfb07e5a2f