### PR TITLE
feat: add chaturbate token mapping and overlay goal

### DIFF
--- a/app/main.js
+++ b/app/main.js
@@ -41,11 +41,15 @@ function createWindow(){
   const { width, height, x, y } = screen.getPrimaryDisplay().workArea;
   win = new BrowserWindow({ x, y, width, height, backgroundColor: '#00000000', autoHideMenuBar: true });
   win.loadFile(path.join(__dirname,'../web/splash.html'));
+  const readyAt = Date.now() + 5000;
   waitForServer('http://localhost:3000/', (ok)=>{
-    if(ok) win.loadURL('http://localhost:3000/control.html');
-    else win.webContents
-      .executeJavaScript("document.querySelector('.tip').textContent='Server failed to start';")
-      .catch(err => console.error('[ButtCaster] failed to update splash screen', err));
+    const delay = Math.max(0, readyAt - Date.now());
+    setTimeout(()=>{
+      if(ok) win.loadURL('http://localhost:3000/control.html');
+      else win.webContents
+        .executeJavaScript("document.querySelector('.tip').textContent='Server failed to start';")
+        .catch(err => console.error('[ButtCaster] failed to update splash screen', err));
+    }, delay);
   });
   win.on('closed', ()=>{ if(server) server.kill(); });
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,8 @@
       "dependencies": {
         "buttplug": "^3.0.0",
         "express": "^4.19.2",
-        "socket.io": "^4.7.5"
+        "socket.io": "^4.7.5",
+        "ws": "^8.17.0"
       },
       "devDependencies": {
         "electron": "^30.0.8"

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "express": "^4.19.2",
     "socket.io": "^4.7.5",
-    "buttplug": "^3.0.0"
+    "buttplug": "^3.0.0",
+    "ws": "^8.17.0"
   },
   "devDependencies": {
     "electron": "^30.0.8"

--- a/server/chaturbate.js
+++ b/server/chaturbate.js
@@ -1,0 +1,31 @@
+const WebSocket = require('ws');
+
+// Simple Chaturbate tip listener.
+// This is a placeholder implementation using the public tip JSON API.
+// Chaturbate doesn't provide an official public websocket; this example
+// assumes a websocket endpoint that pushes tip events in the form
+// {"type":"tip","amount":<number>}.
+// The details may need adjustment according to actual API behaviour.
+
+function connectChaturbate(room, onTip) {
+  if(!room) throw new Error('Room name required');
+  const url = `wss://events2-mc.chaturbate.com/${room}`;
+  const ws = new WebSocket(url);
+
+  ws.on('open', () => console.log(`[Chaturbate] connected to ${room}`));
+  ws.on('message', msg => {
+    try {
+      const data = JSON.parse(msg.toString());
+      if(data && data.type === 'tip') {
+        onTip(Number(data.amount) || 0);
+      }
+    } catch(e) {
+      console.warn('[Chaturbate] parse error', e);
+    }
+  });
+  ws.on('close', () => console.log('[Chaturbate] connection closed'));
+  ws.on('error', err => console.error('[Chaturbate] error', err));
+  return ws;
+}
+
+module.exports = { connectChaturbate };

--- a/server/index.js
+++ b/server/index.js
@@ -4,6 +4,7 @@ const http = require('http');
 const { Server: SocketIO } = require('socket.io');
 const path = require('path');
 const { connectIntiface, vibrateAll } = require('./intiface.js');
+const { connectChaturbate } = require('./chaturbate.js');
 
 const app = express();
 // Attach Express as the HTTP request handler so Socket.IO's internal
@@ -26,10 +27,43 @@ app.use(express.static(path.join(__dirname,'../web')));
 
 const state = { overlay:{ goalTarget:2000, goalProgress:0, glow:true, watermark:true, elements:[] }, devices:[], intiface:{ url:'ws://127.0.0.1:12345', connected:false }, bpClient:null };
 
+// Mapping from token ranges to vibration patterns.
+// Example entries: {from:1,to:10,duration:1000,pattern:'ramp'}
+const tokenMap = [
+  { from: 1, to: 10, duration: 1000, pattern: 'ramp' },
+  { from: 11, to: 50, duration: 3000, pattern: 'random' },
+  { from: 51, to: 500, duration: 5000, pattern: 'spikes' }
+];
+
+function findMapping(amount){
+  return tokenMap.find(m => amount >= m.from && amount <= m.to);
+}
+
+async function runPattern(state, pattern, duration){
+  switch(pattern){
+    case 'ramp':
+      for(let i=0;i<5;i++){ await vibrateAll(state, i/5, duration/5); }
+      break;
+    case 'random':
+      for(let i=0;i<5;i++){ await vibrateAll(state, Math.random(), duration/5); }
+      break;
+    case 'spikes':
+      for(let i=0;i<5;i++){ await vibrateAll(state, i%2?1:0.2, duration/10); }
+      break;
+    default:
+      await vibrateAll(state, 0.6, duration);
+  }
+}
+
 async function handleTip(amount = 100){
   state.overlay.goalProgress = Math.min(state.overlay.goalTarget, state.overlay.goalProgress + amount);
   io.emit('overlay:goal', { target: state.overlay.goalTarget, current: state.overlay.goalProgress });
-  await vibrateAll(state, Math.min(1, Math.max(.25, amount / 250)), 1200);
+  const map = findMapping(amount);
+  if(map){
+    await runPattern(state, map.pattern, map.duration);
+  } else {
+    await vibrateAll(state, Math.min(1, Math.max(.25, amount / 250)), 1200);
+  }
 }
 
 app.post('/api/intiface/connect', async (req,res)=>{
@@ -69,3 +103,8 @@ app.get('/', (req,res)=> res.sendFile(path.join(__dirname,'../web/control.html')
 const PORT = process.env.PORT || 3000;
 httpServer.listen(PORT, ()=> console.log(`[ButtCaster] server on http://localhost:${PORT}`));
 server.on('request', app);
+
+// Connect to Chaturbate if room provided via env CHATURBATE_ROOM
+if(process.env.CHATURBATE_ROOM){
+  connectChaturbate(process.env.CHATURBATE_ROOM, amt => handleTip(amt));
+}

--- a/web/js/overlay.js
+++ b/web/js/overlay.js
@@ -1,0 +1,24 @@
+import { connectIntiface, onDeviceCount } from "./intiface.js";
+import { applyCanvasScale } from "./canvas-scale.js";
+
+applyCanvasScale(".stage", ".canvas-abs");
+connectIntiface().catch(console.error);
+onDeviceCount(n => console.log("[Overlay] Devices:", n));
+
+const socket = io();
+const bar = document.getElementById('goal-progress');
+const label = document.getElementById('goal-label');
+let target = 0;
+
+socket.on('overlay:goal', ({ target:t, current }) => {
+  target = t;
+  const pct = Math.min(1, current / target);
+  bar.style.width = `${pct * 100}%`;
+  label.textContent = `${current}/${target} tokens`;
+  if (pct >= 1) launchConfetti();
+});
+
+function launchConfetti(){
+  import('https://cdn.jsdelivr.net/npm/canvas-confetti@1.6.0/dist/confetti.mjs')
+    .then(m => m.default());
+}

--- a/web/overlay.html
+++ b/web/overlay.html
@@ -44,6 +44,9 @@
     .canvas-abs { position:absolute; inset:0; transform-origin:0 0; min-width:100%; }
     /* Example element for visual check */
     .pill { position:absolute; left:24px; top:24px; padding:10px 14px; border-radius:18px; background:var(--pill); color:#111; font-weight:900; box-shadow: 0 10px 30px rgba(120,60,140,.18); }
+    #goal-container{position:absolute; bottom:24px; left:24px; width:320px; height:24px; background:rgba(255,255,255,.2); border-radius:12px; overflow:hidden; box-shadow:0 6px 18px rgba(60,80,130,.12);}
+    #goal-progress{height:100%; width:0%; background:var(--pill); transition:width .3s;}
+    #goal-label{position:absolute; inset:0; display:flex; align-items:center; justify-content:center; font-weight:800; color:#111;}
     header { position:fixed; left:16px; top:16px; display:flex; gap:10px; align-items:center; z-index:5; }
     header img { width:28px; height:28px; }
     /* OBS suggestion: set browser source to 1920x1080, enable transparency */
@@ -64,18 +67,12 @@
       <div class="glow"></div>
       <div class="canvas-abs" id="canvas-abs">
         <div class="pill">ButtCaster Overlay</div>
+        <div id="goal-container"><div id="goal-progress"></div><span id="goal-label"></span></div>
       </div>
     </div>
   </div>
 
-  <script type="module">
-    import { connectIntiface, onDeviceCount } from "./js/intiface.js";
-    import { applyCanvasScale } from "./js/canvas-scale.js";
-
-    applyCanvasScale(".stage", ".canvas-abs");
-    // Auto-connect on overlay load; adjust URL if needed
-    connectIntiface("ws://127.0.0.1:12345").catch(console.error);
-    onDeviceCount(n => console.log("[Overlay] Devices:", n));
-  </script>
+  <script src="/socket.io/socket.io.js"></script>
+  <script type="module" src="./js/overlay.js"></script>
 </body>
 </html>

--- a/web/splash.html
+++ b/web/splash.html
@@ -8,10 +8,20 @@
   .card{padding:32px 44px; border-radius:20px; background:linear-gradient(180deg,rgba(255,255,255,.06),rgba(255,255,255,.03)); box-shadow:0 30px 60px rgba(0,0,0,.35); border:1px solid rgba(255,255,255,.07)}
   .logo{display:block; width:min(520px,80vw)}
   .bar{height:4px; background:rgba(255,255,255,.08); border-radius:999px; overflow:hidden; margin-top:18px}
-  .bar::before{content:""; display:block; height:100%; width:40%; background:linear-gradient(90deg,#ff6ec7,#6ea8ff); border-radius:inherit; animation:load 1.6s ease-in-out infinite}
-  @keyframes load{50%{transform:translateX(150%)} 100%{transform:translateX(300%)}}
+  .bar-inner{height:100%; width:0%; background:linear-gradient(90deg,#ff6ec7,#6ea8ff); border-radius:inherit;}
   .tip{color:#aeb8ff; font:600 12px/1.6 Calibri,Inter,Segoe UI,Arial; text-align:center; opacity:.9; margin-top:10px}
 </style>
 </head><body>
-  <div class="wrap"><div class="card"><img class="logo" src="/img/logo.svg" alt="ButtCaster"/><div class="bar"></div><div class="tip">Launching Control…</div></div></div>
+  <div class="wrap"><div class="card"><img class="logo" src="/img/logo.svg" alt="ButtCaster"/><div class="bar"><div class="bar-inner"></div></div><div class="tip">Launching Control…</div></div></div>
+  <script>
+    const bar = document.querySelector('.bar-inner');
+    const start = Date.now();
+    const duration = 5000;
+    function update(){
+      const pct = Math.min(1, (Date.now()-start)/duration);
+      bar.style.width = (pct*100)+'%';
+      if(pct<1) requestAnimationFrame(update);
+    }
+    update();
+  </script>
 </body></html>


### PR DESCRIPTION
## Summary
- integrate placeholder Chaturbate websocket listener
- map token ranges to vibration patterns and update overlay goal
- add overlay progress bar, confetti celebration, and timed splash screen

## Testing
- `npm test` *(fails: Missing script "test")*


------
https://chatgpt.com/codex/tasks/task_e_68bc10dee1888333bf3a11e0cc9ab6ca